### PR TITLE
Remove hard code connection string

### DIFF
--- a/Startup_Pro/AddHealthCheck.cs
+++ b/Startup_Pro/AddHealthCheck.cs
@@ -13,15 +13,15 @@ namespace InfraLib.Startup_Pro
             _ = builder.Services
                 .AddHealthChecks()
                 .AddSqlServer(
-                    @"Data Source=DIPESH-PANSURIY\SQLEXPRESS; Initial Catalog=masterdb; User Id=dbsa; Password=India_123456;MultipleActiveResultSets=True; Connection Timeout=300; TrustServerCertificate=true;Trusted_Connection=True",
+                    AppSettings.dbSettings.MastersDb,
                     healthQuery: "SELECT 1;",
                     name: "Masters Database")
                 .AddSqlServer(
-                    @"Data Source=DIPESH-PANSURIY\SQLEXPRESS; Initial Catalog=masterlogdb; User Id=dbsa; Password=India_123456;MultipleActiveResultSets=True; Connection Timeout=300; TrustServerCertificate=true;Trusted_Connection=True",
+                    AppSettings.dbSettings.MastersLogDb,
                     healthQuery: "SELECT 1;",
                     name: "Master Log Database")
                 .AddSqlServer(
-                    @"Data Source=DIPESH-PANSURIY\SQLEXPRESS; Initial Catalog=masterhangfiredb; User Id=dbsa; Password=India_123456;MultipleActiveResultSets=True; Connection Timeout=300; TrustServerCertificate=true;Trusted_Connection=True",
+                    AppSettings.dbSettings.MastersHangfireDb,
                     healthQuery: "SELECT 1;",
                     name: "Master Hangfire Database")
                 .AddHangfire(


### PR DESCRIPTION
This pull request includes an important change to the `Builder` method in the `Startup_Pro/AddHealthCheck.cs` file. The change replaces hardcoded database connection strings with references to settings from the `AppSettings` configuration.

Configuration improvements:

* [`Startup_Pro/AddHealthCheck.cs`](diffhunk://#diff-d8020c474b8ec5b3d3d89834c5b71c58eb9ce0beb9b78257d37b80703bcae00bL16-R24): Updated the `Builder` method to use `AppSettings.dbSettings` for the `MastersDb`, `MastersLogDb`, and `MastersHangfireDb` connection strings instead of hardcoded values.Remove hard code connection string